### PR TITLE
Slight HalfLifeMap improvements

### DIFF
--- a/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
+++ b/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
@@ -224,17 +224,18 @@ public final class HalfLifeMap<K, V> extends AbstractMap2<K, V> implements
 	/**
 	 * Lower all the counts. This is triggered periodically by calls to get()
 	 */
-	synchronized void devalue() {
-		if (devalueCount < devalueInterval) {
-			return; // race condition -- someone else has already devalued
+	public void devalue() {
+		synchronized(this) {
+			if (devalueCount < devalueInterval) {
+				return; // race condition -- someone else has already devalued
+			}
+			devalueCount = 0;
 		}
 		// Copy to avoid concurrent mod errors
 		HLEntry<K, V>[] hvs = map.values().toArray(new HLEntry[0]);
 		for (HLEntry<K, V> e : hvs) {
 			e.count *= 0.9;
 		}
-		// ??Could we move this earlier in the method, & limit the synchronized block to just the test-and-set-to-0??  
-		devalueCount = 0;
 	}
 
 	/**

--- a/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
+++ b/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -113,7 +114,7 @@ public class HalfLifeMapTest {
 	@Test
 	public void testValues() {
 		// half-life
-		HalfLifeMap map = new HalfLifeMap(4);
+		HalfLifeMap map = new HalfLifeMap<>(4);
 		Collection vs = map.values();
 		assert vs.isEmpty();
 		for(int i=0; i<10; i++) {
@@ -140,6 +141,77 @@ public class HalfLifeMapTest {
 		
 	}
 
+	@Test
+	public void testGet() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+		map.put("Fred", "Wilma");
+
+		assert map.get("Fred") == "Wilma";
+	}
+
+	@Test
+	public void testGetKeyNotPresent() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+		map.put("Fred", "Wilma");
+
+		assert map.get("Barney") == null;
+	}
+
+	@Test
+	public void testGetMapEmpty() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+
+		assert map.get("Barney") == null;
+	}
+
+	@Test
+	public void testRemove() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+		map.put("Fred", "Wilma");
+
+		String retVal = map.remove("Fred");
+
+		assert map.get("Fred") == null;
+		assert retVal == "Wilma";
+		assert map.size() == 0;
+	}
+
+	@Test
+	public void testRemoveKeyNotPresent() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+		map.put("Fred", "Wilma");
+
+		String retVal = map.remove("Barney");
+
+		assert map.get("Barney") == null;
+		assert retVal == null;
+		assert map.size() == 1;
+	}
+
+	@Test
+	public void testRemoveEmpty() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+
+		String retVal = map.remove("Barney");
+
+		assert map.get("Barney") == null;
+		assert retVal == null;
+		assert map.size() == 0;
+	}
+
+	@Test
+	public void testRemoveNotLastItem() {
+		HalfLifeMap<String, String> map = new HalfLifeMap<>(1);
+		map.put("Fred", "Wilma");
+		map.put("Barney", "Betty");
+
+		String retVal = map.remove("Fred");
+
+		assert map.get("Fred") == null;
+		assert retVal == "Wilma";
+		assert map.size() == 1;
+	}
+
 	/**
 	 * Conclusion: HalLifeMap has little overhead for get, about twice as slow
 	 * for put.
@@ -147,7 +219,7 @@ public class HalfLifeMapTest {
 	@Test
 	public void testSpeed() {
 		// half-life
-		HalfLifeMap map = new HalfLifeMap(100);
+		HalfLifeMap map = new HalfLifeMap<>(100);
 		Log.setMinLevel(Level.OFF);
 		{
 			double perOp1a = speed2_heavyGet(map);
@@ -204,7 +276,7 @@ public class HalfLifeMapTest {
 
 	@Test
 	public void testSerialisation() {
-		HalfLifeMap<String, Object> index = new HalfLifeMap(10);
+		HalfLifeMap<String, Object> index = new HalfLifeMap<>(10);
 
 		index.put("A", 1);
 		index.put("B", 2);
@@ -225,5 +297,216 @@ public class HalfLifeMapTest {
 
 		assert !wxml.toLowerCase().contains("concurrent");
 
+	}
+
+	@Test
+	public void testToString() {
+		HalfLifeMap<String, Object> map = new HalfLifeMap<>(10);
+
+		map.put("A", 1);
+		map.put("B", 2);
+		String str = map.toString();
+
+		assert str.equals("HalfLifeMap[A,B... 2]");
+	}
+
+	@Test
+	public void testItemToString() {
+		HalfLifeMap<String, Object> map = new HalfLifeMap<>(10);
+		map.put("A", 3);
+		Map<String, HLEntry<String, Object>> inner = map.getBaseMap();
+		HLEntry entry = inner.get("A");
+		String str = entry.toString();
+
+		assert str.equals("HLEntry [count=1.0, val=3]");
+	}
+
+	@Test
+	public void testItemClone() {
+		HLEntry<String, Double> hle = new HLEntry<>("Fred", 7.3);
+		HLEntry<String, Double> hle2 = hle.clone();
+
+		assert hle2.getKey() == "Fred";
+		assert hle2.getValue() == 7.3;
+		assert hle2.count == hle.count;
+	}
+
+	@Test
+	public void testClone() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(10);
+		map.put("Fred",  7.0);
+		map.put("Barney", 9.3);
+		map.put("Fred", 39.4);
+		HalfLifeMap<String, Double> map2 = map.clone();
+
+		assert map2.get("Fred") == 39.4;
+		assert map2.get("Barney") == 9.3;
+		assert map2.getCount("Fred") == 3;
+	}
+
+	@Test
+	public void testCloneCreatesNewObjects() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(10);
+		map.put("Fred",  7.0);
+		map.put("Barney", 9.3);
+		HalfLifeMap<String, Double> map2 = map.clone();
+		map.put("Fred", 39.4);
+		map.remove("Barney");
+
+		assert !map.containsKey("Barney");
+		assert map2.containsKey("Barney");
+		assert map2.get("Fred") == 7.0;
+	}
+
+	@Test
+	public void testTotalCount() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(10);
+		map.put("Fred",  7.0);
+		map.put("Barney", 9.3);
+		map.put("Fred", 39.4);
+
+		assert map.getTotalCount() == 3.0;
+	}
+
+	@Test
+	public void testDevalue() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.put("Fred",  7.0);
+		int count = 1;
+		for (int i = 0; i < map.devalueInterval + 1; i++) {
+			map.get("Fred");
+			count++;
+		}
+
+		assert map.devalueCount == 0; // reset after every devaluation
+		assert map.getTotalCount() == 0.9 * count;
+	}
+
+	@Test
+	public void testDevalueRaceCondition() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.put("Fred",  7.0);
+		double previousTotal = map.getTotalCount();
+
+		assert map.devalueCount < map.devalueInterval;
+		map.devalue();  // should be ignored
+		assert map.getTotalCount() == previousTotal;
+	}
+
+	@Test
+	public void testGetCount() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.put("Fred",  7.0);
+
+		assert map.getCount("Fred") == 1;
+	}
+
+	@Test
+	public void testGetCountNotPresent() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.put("Fred",  7.0);
+
+		assert map.getCount("Barney") == 0;
+	}
+
+	@Test
+	public void testPrunedValueDefaults() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		// by default, pruned value is untracked (represented by NaN)
+		assert Double.isNaN(map.getPrunedValue());
+		map.setTrackPrunedValue(true);
+		// set it to track, but don't prune any value
+		assert map.getPrunedValue() == 0;
+		// now set it to stop tracking
+		map.setTrackPrunedValue(false);
+		assert Double.isNaN(map.getPrunedValue());
+	}
+
+	@Test
+	public void testGetPrunedValue() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.setTrackPrunedValue(true);
+
+		// Only Fred will survive the upcoming prune
+		map.put("Fred", 9.0);
+		map.get("Fred"); map.get("Fred");
+		assert map.getCount("Fred") == 3;
+
+		// trigger a prune by inserting > 2 * ideal_size elements
+		map.put("Barney", 7.4);
+		map.put("Wilma", 34.6);
+
+		assert map.getPrunedCount() == 2;
+		assert !map.containsKey("Barney");
+		assert !map.containsKey("Wilma");
+		assert map.getPrunedValue() == 42.0;
+	}
+
+	@Test
+	public void testClear() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.setTrackPrunedValue(true);
+		map.put("Fred", 9.0);
+		map.get("Fred"); map.get("Fred");
+		map.put("Barney", 7.4);
+		map.prune();
+		assert map.getPrunedCount() == 1;
+
+		map.clear();
+
+		assert map.getPrunedCount() == 0;
+		assert map.getPrunedValue() == 0.0;
+	}
+
+	public class KeyListener<K, V> implements IPruneListener<K, V> {
+		List<K> prunedKeys;
+
+		public KeyListener() {
+			prunedKeys = new ArrayList<K>(1);
+		}
+
+		@Override
+		public void pruneEvent(List<Entry<K, V>> pruned) {
+			for (Map.Entry<K, V> entry: pruned) {
+				prunedKeys.add(entry.getKey());
+			}
+		}
+	}
+
+	@Test
+	public void testListeners() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.put("Fred", 9.0);
+		KeyListener<String, Double> listener = new KeyListener<>();
+		map.addListener(listener);
+		map.put("Barney", 31337.0);
+		map.prune();
+
+		assert map.listeners.contains(listener);
+		assert listener.prunedKeys.contains("Barney");
+	}
+
+	@Test
+	public void testRemoveListeners() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		map.put("Fred", 9.0);
+		KeyListener<String, Double> listener = new KeyListener<>();
+		map.addListener(listener);
+		map.removeListener(listener);
+		map.put("Barney", 31337.0);
+		map.prune();
+
+		assert !map.listeners.contains(listener);
+		assert !listener.prunedKeys.contains("Barney");
+	}
+
+	@Test
+	public void testListenersAreNotCloned() {
+		HalfLifeMap<String, Double> map = new HalfLifeMap<>(1);
+		KeyListener<String, Double> listener = new KeyListener<>();
+		map.addListener(listener);
+		HalfLifeMap<String, Double> map2 = map.clone();
+
+		assert map2.listeners == null;
 	}
 }

--- a/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
+++ b/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
@@ -154,38 +154,48 @@ public class HalfLifeMapTest {
 			double perOp1b = speed2_heavyGet(Collections.synchronizedMap(new HashMap()));
 			double pc = 100*((perOp1a/perOp1b)-1);
 			System.out.println("Mostly Gets: HalfLifeMap "+perOp1a +" vs HashMap "+perOp1b+":\t"+StrUtils.toNSigFigs(pc, 2)+"%");
+			System.out.println("Prunes: " + map.getPrunedCount());
+			System.out.println("Map size: " + map.size());
+			System.out.println("Total count: " + map.getTotalCount());
 		}
 		{
 			double perOp1a = speed2_heavyPut(map);
 			double perOp1b = speed2_heavyPut(Collections.synchronizedMap(new HashMap()));
 			double pc = 100*((perOp1a/perOp1b)-1);
 			System.out.println("Mostly Puts: HalfLifeMap "+perOp1a +" vs HashMap "+perOp1b+":\t"+StrUtils.toNSigFigs(pc, 2)+"%");
+			System.out.println("Prunes: " + map.getPrunedCount());
+			System.out.println("Map size: " + map.size());
+			System.out.println("Total count: " + map.getTotalCount());
 		}
 		assert map.size() <= map.getIdealSize()*2;
 	}
 	
 	private double speed2_heavyGet(Map map) {
+		Utils.PowerLawDistribution dist = new Utils.PowerLawDistribution(0.1);
 		StopWatch sw = new StopWatch();
 		int ops = 0;
-		for(int i=0; i<10000; i++) {
-			map.put(Utils.getRandomString(2), i);
+		for(int i=0; i<100000; i++) {
+			int key_length = 2;
+			map.put(dist.getRandomString(key_length), i);
 			ops++;
 			for(int j=0; j<1000; j++) {
-				map.get(Utils.getRandomString(2));
+				map.get(dist.getRandomString(key_length));
 				ops++;
 			}
 		}
 		return (1.0*sw.getTime())/ops;
 	}
-	
+
 	private double speed2_heavyPut(Map map) {
+		Utils.PowerLawDistribution dist = new Utils.PowerLawDistribution(0.1);
 		StopWatch sw = new StopWatch();
 		int ops = 0;
 		for(int i=0; i<100000; i++) {
-			map.get(Utils.getRandomString(2));
+			int key_length = 2;
+			map.get(dist.getRandomString(key_length));
 			ops++;
 			for(int j=0; j<10; j++) {
-				map.put(Utils.getRandomString(2), j);
+				map.put(dist.getRandomString(key_length), j);
 				ops++;
 			}
 		}

--- a/winterwell.utils/src/com/winterwell/utils/Utils.java
+++ b/winterwell.utils/src/com/winterwell/utils/Utils.java
@@ -45,6 +45,8 @@ public class Utils {
 
 	private static final char[] vowels = "aeiouy".toCharArray();
 
+	private static final char[] letters = "abcdefghijklmnopqrstuvwxyz".toCharArray();
+
 	/**
 	 * Check inputs are all non-null
 	 * 
@@ -290,6 +292,37 @@ public class Utils {
 			s[i] = c;
 		}
 		return new String(s);
+	}
+	
+	public static class PowerLawDistribution {
+		double exponent;
+		double total = 0;
+		Random rnd;
+		double[] partial_sums;
+		
+		public PowerLawDistribution(double exponent) {
+			this.exponent = exponent;
+			rnd = getRandom();
+			partial_sums = new double[26];
+			for (int i = 0; i < 26; i++) {
+				total += Math.pow(i + 1, -exponent);
+				partial_sums[i] = total;
+			}
+		}
+		
+		public String getRandomString(int len) {
+			char[] s = new char[len];
+			for (int j = 0; j < len; j++) {
+				double draw = rnd.nextDouble() * total;
+				for (int i = 0; i < 26; i++) {
+					if (draw < partial_sums[i]) {
+						s[j] = letters[i];
+						break;
+					}
+				}
+			}
+			return new String(s);
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Increase test coverage to 90%
- Use power-law distributed keys in speed tests rather than uniformly-distributed ones
- Shrink the synchronized block in devalue().