### PR TITLE
Make build tasks more robust

### DIFF
--- a/winterwell.bob/build/jobs/BuildWinterwellProject.java
+++ b/winterwell.bob/build/jobs/BuildWinterwellProject.java
@@ -90,7 +90,7 @@ public class BuildWinterwellProject extends BuildTask {
 		
 		// copy into code/lib
 		File lib = new File(FileUtils.getWinterwellDir(), "code/lib");
-		lib.mkdir();
+		lib.mkdirs();
 		FileUtils.copy(jarFile, lib);
 		Log.d(LOGTAG, "Copied "+jarFile.getName()+" to "+lib);
 	}

--- a/winterwell.bob/src/com/winterwell/bob/tasks/JarTask.java
+++ b/winterwell.bob/src/com/winterwell/bob/tasks/JarTask.java
@@ -201,7 +201,11 @@ public class JarTask extends BuildTask {
 				entry = zin.getNextEntry();
 			}
 			// Delete temp file
-			FileUtils.delete(tempFile);
+			try {
+				FileUtils.delete(tempFile);
+			} catch (Exception e) {
+				Log.w(LOGTAG, e);
+			}
 		}
 		// Add manifest
 		addManifest(out);


### PR DESCRIPTION
 - Make $WINTERWELL_HOME/code directory if it doesn't exist (we write jars to
   code/libs)
 - Carry on if (say) deleting tempfiles fails (happens on Windows)