### PR TITLE
Revert QuickSelect-based HalfLifeMap :-(

### DIFF
--- a/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
+++ b/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.winterwell.maths.stats.StatsUtils;
 import com.winterwell.utils.Printer;
 import com.winterwell.utils.Utils;
 import com.winterwell.utils.containers.AbstractMap2;
@@ -325,24 +324,29 @@ public final class HalfLifeMap<K, V> extends AbstractMap2<K, V> implements
 		if (size() <= idealSize) return;
 		Log.v("map", "prune!");
 		// Copy out of the backing map
-		HLEntry[] entries = map.values().toArray(new HLEntry[0]);
-		double[] counts = new double[entries.length];
-		for (int i = 0; i < entries.length; i++) {
-			counts[i] = entries[i].count;
-		}
-		double cutoff = StatsUtils.select(size() - idealSize - 1, counts);
-		// What to prune?
-		int numberToPrune = size() - idealSize;
-		if (numberToPrune <= 0) {
-			return;
-		}
-		List<HLEntry> toPrune = new ArrayList<HLEntry>(numberToPrune);
-		for (HLEntry e : map.values()) {
-			// Use <= in case there are many entries with the cutoff value
-			if (e.count <= cutoff) {
-				toPrune.add(e);
+		List<HLEntry> entries = Arrays.asList(map.values().toArray(new HLEntry[0]));
+		if (entries.size() <= idealSize) return; // race condition
+		// sort by score
+		// NB: HLEntry score could mutate under us, which could cause
+		// > java.lang.IllegalArgumentException: Comparison method violates its general contract!
+		boolean sorted = false;
+		for(int i=0; i<5; i++) {
+			try {
+				Collections.sort(entries);
+				sorted = true;
+				break;
+			} catch(IllegalArgumentException ex) {
+				// try again...
+				Log.d("HalfLifeMap", "Rare concurrency issue: "+ex);
 			}
 		}
+		if ( ! sorted) {
+			// failed x5?! Copy them out instead
+			entries = entries.stream().map(hle -> hle.clone()).collect(Collectors.toList());
+			Collections.sort(entries);
+		}
+		// What to prune?
+		List<HLEntry> toPrune = entries.subList(0, entries.size() - idealSize);
 		// prune
 		boolean track = ! Double.isNaN(prunedValue);
 		for (HLEntry e : toPrune) {

--- a/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
+++ b/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
@@ -332,7 +332,11 @@ public final class HalfLifeMap<K, V> extends AbstractMap2<K, V> implements
 		}
 		double cutoff = StatsUtils.select(size() - idealSize - 1, counts);
 		// What to prune?
-		List<HLEntry> toPrune = new ArrayList<HLEntry>(size() - idealSize);
+		int numberToPrune = size() - idealSize;
+		if (numberToPrune <= 0) {
+			return;
+		}
+		List<HLEntry> toPrune = new ArrayList<HLEntry>(numberToPrune);
 		for (HLEntry e : map.values()) {
 			// Use <= in case there are many entries with the cutoff value
 			if (e.count <= cutoff) {

--- a/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
+++ b/winterwell.maths/src/com/winterwell/maths/datastorage/HalfLifeMap.java
@@ -322,20 +322,17 @@ public final class HalfLifeMap<K, V> extends AbstractMap2<K, V> implements
 	 * exposed for debugging/testing purposes.
 	 */
 	public void prune() {
-		int size = size();
-		if (size <= idealSize) return;
+		if (size() <= idealSize) return;
 		Log.v("map", "prune!");
 		// Copy out of the backing map
-		double[] counts = new double[size];
-		{
-			int i = 0;
-			for (HLEntry entry : map.values()) {
-				counts[i++] = entry.count;
-			}
+		HLEntry[] entries = map.values().toArray(new HLEntry[0]);
+		double[] counts = new double[entries.length];
+		for (int i = 0; i < entries.length; i++) {
+			counts[i] = entries[i].count;
 		}
-		double cutoff = StatsUtils.select(size - idealSize - 1, counts);
+		double cutoff = StatsUtils.select(size() - idealSize - 1, counts);
 		// What to prune?
-		List<HLEntry> toPrune = new ArrayList<HLEntry>(size - idealSize);
+		List<HLEntry> toPrune = new ArrayList<HLEntry>(size() - idealSize);
 		for (HLEntry e : map.values()) {
 			// Use <= in case there are many entries with the cutoff value
 			if (e.count <= cutoff) {

--- a/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
+++ b/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
@@ -275,6 +275,25 @@ public class HalfLifeMapTest {
 	}
 
 	@Test
+	public void testConcurrency() {
+		HalfLifeMap map = new HalfLifeMap<>(25000);
+		// Log.setMinLevel(Level.OFF);
+		Thread[] threads = new Thread[10];
+		for (int i = 0; i < 10; i++) {
+			threads[i] = new Thread(() -> speed2_heavyPut(map));
+			threads[i].start();
+		}
+		for (Thread t: threads) {
+			try {
+				t.join();
+			} catch (InterruptedException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+	}
+
+	@Test
 	public void testSerialisation() {
 		HalfLifeMap<String, Object> index = new HalfLifeMap<>(10);
 

--- a/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
+++ b/winterwell.maths/test/com/winterwell/maths/datastorage/HalfLifeMapTest.java
@@ -77,7 +77,7 @@ public class HalfLifeMapTest {
 		assert index.containsKey("11");
 		// prune: keep sa
 		index.prune();
-		assert index.size() == 10;
+		assert index.size() == 10 : index.size();
 		assert index.containsKey("2") : index;
 		assert index.containsKey("6");
 		assert ! index.containsKey("11") : index;


### PR DESCRIPTION
Getting it to work safely in a multithreaded environment is beyond my current abilities :-(

This pull request adds a test for concurrent behaviour, and leaves the functions `select` and `median` in StatsUtils.