### PR TITLE
Split out different map factories used by FrequencyCondDistribution

### DIFF
--- a/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
+++ b/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
@@ -32,6 +32,7 @@ public class FrequencyCondDistribution<X, C> extends
 	 * @return a new Map
 	 */
 	protected final Function<C, Map> newMap;
+	protected final Supplier<Map> newGenericMap;
 	
 	protected final Map<C, ObjectDistribution<X>> dists;
 
@@ -46,17 +47,20 @@ public class FrequencyCondDistribution<X, C> extends
 	 * secondary marginal->prob maps.
 	 */
 	public FrequencyCondDistribution(Supplier<Map> newMap) {
-		this(newMap, (c) -> newMap.get());
+		this(newMap, newMap, (c) -> newMap.get());
 	}
 
 	/**
 	 * @param newDistMap factory function for the top-level context->marginal map
+	 * @param newGenericMap factory function for the "generic" marginal map
 	 * @param newMap factory function for the secondary marginal->prob maps
 	 */
-	public FrequencyCondDistribution(Supplier<Map> newDistMap, Function<C, Map> newMap) {
+	public FrequencyCondDistribution(Supplier<Map> newDistMap, Supplier<Map> newGenericMap, Function<C, Map> newMap) {
 		this.newMap = newMap;
+		this.newGenericMap = newGenericMap;
 		assert newMap!=null;
 		assert newDistMap != null;
+		assert newGenericMap != null;
 		dists = newDistMap.get();
 //		generic = new ObjectDistribution<X>(newMap.get(), false).setPseudoCount(pseudoCount);
 	}
@@ -93,7 +97,11 @@ public class FrequencyCondDistribution<X, C> extends
 	public ObjectDistribution<X> getCreateMarginal(C context) {
 		ObjectDistribution<X> dist = dists.get(context);
 		if (dist == null) {
-			dist = new ObjectDistribution<X>(newMap.apply(context), false);
+			if (context == GENERIC) {
+				dist = new ObjectDistribution<X>(newGenericMap.get(), false);
+			} else {
+				dist = new ObjectDistribution<X>(newMap.apply(context), false);
+			}
 			dist.setPseudoCount(pseudoCount);
 			dists.put(context, dist);
 		}

--- a/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
+++ b/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
@@ -3,6 +3,7 @@ package com.winterwell.maths.stats.distributions.cond;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.winterwell.maths.ITrainable;
@@ -30,7 +31,7 @@ public class FrequencyCondDistribution<X, C> extends
 	 * secondary marginal->prob map.
 	 * @return a new Map
 	 */
-	protected final Supplier<Map> newMap;
+	protected final Function<C, Map> newMap;
 	
 	protected final Map<C, ObjectDistribution<X>> dists;
 
@@ -45,14 +46,14 @@ public class FrequencyCondDistribution<X, C> extends
 	 * secondary marginal->prob maps.
 	 */
 	public FrequencyCondDistribution(Supplier<Map> newMap) {
-		this(newMap, newMap);
+		this(newMap, (c) -> newMap.get());
 	}
 
 	/**
 	 * @param newDistMap factory function for the top-level context->marginal map
 	 * @param newMap factory function for the secondary marginal->prob maps
 	 */
-	public FrequencyCondDistribution(Supplier<Map> newDistMap, Supplier<Map> newMap) {
+	public FrequencyCondDistribution(Supplier<Map> newDistMap, Function<C, Map> newMap) {
 		this.newMap = newMap;
 		assert newMap!=null;
 		assert newDistMap != null;
@@ -92,7 +93,7 @@ public class FrequencyCondDistribution<X, C> extends
 	public ObjectDistribution<X> getCreateMarginal(C context) {
 		ObjectDistribution<X> dist = dists.get(context);
 		if (dist == null) {
-			dist = new ObjectDistribution<X>(newMap.get(), false);
+			dist = new ObjectDistribution<X>(newMap.apply(context), false);
 			dist.setPseudoCount(pseudoCount);
 			dists.put(context, dist);
 		}

--- a/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
+++ b/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
@@ -39,16 +39,24 @@ public class FrequencyCondDistribution<X, C> extends
 	public FrequencyCondDistribution() {
 		this(HashMap::new);
 	}
-	
+
 	/**
-	 * Override to use e.g. HalfLifeMap. This is used for both the top-level context->marginal map, and the
-	 * secondary marginal->prob map.
-	 * @return a new Map
+	 * @param newMap factory function used for both the top-level context->marginal map, and the
+	 * secondary marginal->prob maps.
 	 */
 	public FrequencyCondDistribution(Supplier<Map> newMap) {
+		this(newMap, newMap);
+	}
+
+	/**
+	 * @param newDistMap factory function for the top-level context->marginal map
+	 * @param newMap factory function for the secondary marginal->prob maps
+	 */
+	public FrequencyCondDistribution(Supplier<Map> newDistMap, Supplier<Map> newMap) {
 		this.newMap = newMap;
 		assert newMap!=null;
-		dists = newMap.get();
+		assert newDistMap != null;
+		dists = newDistMap.get();
 //		generic = new ObjectDistribution<X>(newMap.get(), false).setPseudoCount(pseudoCount);
 	}
 	

--- a/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/IFrequencyCondMapBuilder.java
+++ b/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/IFrequencyCondMapBuilder.java
@@ -1,0 +1,22 @@
+package com.winterwell.maths.stats.distributions.cond;
+
+import java.util.Map;
+
+/**
+ * @author miles
+ * 
+ * Interface to be implemented by factory objects for FrequencyCondDistribution,
+ * which needs to be able to construct three possibly distinct types of Map:
+ * 
+ *  - a top-layer map from contexts to marginal maps
+ *  - a "generic" map for cases where we don't know the marginal distribution
+ *  - individual marginal distributions.
+ *  
+ *  Yes, I know this is hilarious overkill.
+ */
+public interface IFrequencyCondMapBuilder<C> {
+	
+	public Map newDistributionMap();
+	public Map newGenericMap();
+	public Map newMarginalMap(C context);
+}


### PR DESCRIPTION
We were assuming the same factory function would be used to create all three types of maps used by FrequencyCondDistribution:

 - the context -> marginal distribution map
 - the "generic" distribution
 - the marginal distributions.

I've made them all individually settable via a factory object with three methods, which you pass in at construction time. The old "pass in one function" interface will still work, it just creates a factory which delegates to the function.