### PR TITLE
Make FrequencyCondDistribution.getGeneric() public

### DIFF
--- a/winterwell.maths/.classpath
+++ b/winterwell.maths/.classpath
@@ -14,6 +14,6 @@
 	<classpathentry kind="lib" path="/middleware/jakarta/commons-math3.jar" sourcepath="/home/daniel/winterwell/code/middleware/jakarta/commons-math3-3.6.1-sources.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/winterwell.utils"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/winterwell.web"/>
-	<classpathentry exported="true" kind="lib" path="/middleware/trove/trove.jar"/>
+        <classpathentry exported="true" kind="lib" path="/middleware/trove/trove.jar" sourcepath="/middleware/trove/trove-src.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
+++ b/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/FrequencyCondDistribution.java
@@ -71,7 +71,7 @@ public class FrequencyCondDistribution<X, C> extends
 		return dist;
 	}
 
-	private ObjectDistribution<X> getGeneric() {
+	public ObjectDistribution<X> getGeneric() {
 		// cheat and use erasure
 		return getCreateMarginal((C)GENERIC);
 	}


### PR DESCRIPTION
We couldn't duplicate the erasure logic in a subclass method; this was causing exceptions in ZoneFox AI.