### PR TITLE
Handle empty lists in ListSitnStream constructor

### DIFF
--- a/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/ListSitnStream.java
+++ b/winterwell.maths/src/com/winterwell/maths/stats/distributions/cond/ListSitnStream.java
@@ -21,9 +21,9 @@ public class ListSitnStream<X> implements ISitnStream<X> {
 
 	public ListSitnStream(List<Sitn<X>> list) {
 		this(list,
-			// just take the first sig?!
-			list.get(0).context.sig
-			);
+			// just take the first sig, if one exists?!
+			list.size() > 0 ? list.get(0).context.sig : new String[]{}
+		);
 	}
 
 	public ListSitnStream(List<Sitn<X>> list, String[] sig) {

--- a/winterwell.maths/test/com/winterwell/maths/stats/distributions/cond/ListSitnStreamTest.java
+++ b/winterwell.maths/test/com/winterwell/maths/stats/distributions/cond/ListSitnStreamTest.java
@@ -28,4 +28,15 @@ public class ListSitnStreamTest {
 		assert s.equals("DearAlice") : s;
 	}
 
+	@Test
+	public void testEmptyList() {
+		ListSitnStream<String> lss = new ListSitnStream<>(Arrays.asList());
+		String s = "";
+		for (Sitn<String> sitn : lss) {
+			s += sitn.outcome;
+		}
+
+		assertEquals(s, "");
+	}
+
 }


### PR DESCRIPTION
Before the `ListSitnStream` constructor was crashing if given a list with no elements, because it couldn't work out the signature. This PR sets the signature to the empty array in this case.