### PR TITLE
have made changes and comments to the git tasks that bob performs

### DIFF
--- a/winterwell.bob/src/com/winterwell/bob/BobConfig.java
+++ b/winterwell.bob/src/com/winterwell/bob/BobConfig.java
@@ -24,7 +24,7 @@ public class BobConfig {
 
 	public static final Key<Boolean> VERBOSE = new Key<Boolean>("verbose");
 
-	public final static String VERSION_NUMBER = "1.1.15";
+	public final static String VERSION_NUMBER = "1.1.16";
 	
 	@Option(tokens="-cp,-classpath", description="Classpath used for dynamically compiling build scripts. Uses the file1:file2 format of Java")
 	// NB: This is not the classpath used for CompileTasks which are part of a build script run.

--- a/winterwell.bob/src/com/winterwell/bob/tasks/GitBobProjectTask.java
+++ b/winterwell.bob/src/com/winterwell/bob/tasks/GitBobProjectTask.java
@@ -67,14 +67,37 @@ public class GitBobProjectTask extends BuildTask {
 				gt0.setDepth(getDepth()+1);				
 				gt0.run();
 				gt0.close();
-			}
+			}		
 			// reset first? a harder version of stash!
 			if (resetLocalChanges) {
+				// Garbage Collect the local repository -- helps setup resetting and pulling later
+				Log.d(LOGTAG, "git gc --prune=now (because not a local dev box)");
+				GitTask gc = new GitTask(GitTask.GC, dir);
+				gc.addArg("--prune=now");
+				gc.run();
+				gc.close();
+				// Pull hashes from git server -- regardless of the cleanliness of this pull task, it is 100% necessary before a reset can be accomplished
+				Log.d(LOGTAG, "git pull origin master (because not a local dev box)");
+				GitTask gt = new GitTask(GitTask.PULL, dir);
+				gt.addArg("origin master");
+				gt.run();
+				gt.close();
+				// Reset: Inform the local repository that it should only care about the files/hashes/changes which exist on the canonical git server
 				Log.d(LOGTAG, "git reset --hard (because not a local dev box)");
 				GitTask gr = new GitTask(GitTask.RESET, dir);
 				gr.addArg("--hard FETCH_HEAD");
 				gr.run();
 				gr.close();
+				// Perform what seem to be arbitrary or inert 'checkout' and 'pull' commands, but actually, these help reset a local repository for future incoming commands. Weird, right?
+				Log.d(LOGTAG, "git checkout -f master (because not a local dev box)");
+				GitTask gco = new GitTask(GitTask.CHECKOUT, dir);
+				gco.addArg("-f master");
+				gco.run();
+				gco.close();
+				Log.d(LOGTAG, "git pull (because not a local dev box)");
+				GitTask gp = new GitTask(GitTask.PULL, dir);
+				gp.run();
+				gp.close();
 			}
 			// pull
 			GitTask gt = new GitTask(GitTask.PULL, dir);

--- a/winterwell.bob/src/com/winterwell/bob/tasks/GitTask.java
+++ b/winterwell.bob/src/com/winterwell/bob/tasks/GitTask.java
@@ -146,6 +146,8 @@ public class GitTask extends ProcessTask {
 	public static final String ADD = "add";
 	public static final String CLONE = "clone";
 	public static final String RESET = "reset";
+	public static final String GC = "gc";
+	public static final String CHECKOUT = "checkout";
 
 	private final String action;
 


### PR DESCRIPTION
The idea is that a git repository will always be able to process bob's requests regardless of the last known state of the repository.

Sometimes if either bob or myself perform a 'git reset --hard FETCH_HEAD' on a repository, it can kick back an error regarding how it is unsure of which branch we are telling it to reset to .  This sounds stupid, because it is.  However, it is possible to perform a few successive commands in a row in order to attempt to have the git daemon know exactly what branch we are talking about.