### PR TITLE
Remove snakeyaml from winterwell.datalog .classpath

### DIFF
--- a/winterwell.datalog/.classpath
+++ b/winterwell.datalog/.classpath
@@ -18,6 +18,5 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/youagain-java-client"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/elasticsearch-java-client"/>
 	<classpathentry kind="lib" path="lib/ua_parser.jar" sourcepath="lib/ua_parser.src.zip"/>
-	<classpathentry kind="lib" path="dependencies/snakeyaml.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
this was causing me build errors in Eclipse:

`Project 'winterwell.datalog' is missing required library: 'dependencies/snakeyaml.jar'    winterwell.datalog        Build path    Build Path Problem`

& doesn't *appear* to be used anywhere (at least, SoGive builds without it)