### PR TITLE
Update elastic-search-java-client path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We assume you're doing this in Eclipse.
 You'll also want to get a couple more repos:
 
 	git clone git@github.com:winterstein/flexi-gson.git
-	git clone git@github.com:winterstein/elasticsearch-java-client.git
+	git clone git@github.com:good-loop/elasticsearch-java-client.git
 
 Import projects into Eclipse -- everything in open-code, plus elasticsearch-java-client and flexi-gson
 


### PR DESCRIPTION
Since the winterstein/elasticsearch-java-client README states it is deprecated by good-loop/elasticsearch-java-client, the open-code README should probably point readers to the good-loop/elasticsearch-java-client repository directly.